### PR TITLE
Resolves https://github.com/RomanIakovlev/timeshape/issues/2

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -18,7 +18,7 @@ Timeshape is published on Maven Central. The coordinates are the following:
 <dependency>
     <groupId>net.iakovlev</groupId>
     <artifactId>timeshape</artifactId>
-    <version>2018d.2</version>
+    <version>2018d.3</version>
 </dependency>
 ``` 
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,46 +1,44 @@
+val dataVersion = "2018d"
+val softwareVersion = "3"
+val sevenZSupport = Seq(
+  "org.apache.commons" % "commons-compress" % "1.14",
+  "org.tukaani" % "xz" % "1.6",
+)
 val commonSettings = Seq(
   organization := "net.iakovlev",
-  version := "2018d.3-SNAPSHOT",
+  sonatypeProfileName := "net.iakovlev",
+  version := s"$dataVersion.$softwareVersion",
   crossPaths := false,
   autoScalaLibrary := false,
   publishMavenStyle := true
 )
 
 lazy val core = (project in file("core"))
-  .enablePlugins(JvmPlugin)
   .settings(commonSettings)
   .settings(
-    libraryDependencies := Seq(
+    libraryDependencies ++= Seq(
       "com.esri.geometry" % "esri-geometry-api" % "2.1.0",
-      "org.apache.commons" % "commons-compress" % "1.14",
-      "org.tukaani" % "xz" % "1.6",
       "junit" % "junit" % "4.11" % Test,
       "com.novocode" % "junit-interface" % "0.11" % Test
         exclude ("junit", "junit-dep")
-    ),
+    ) ++ sevenZSupport,
     name := "timeshape",
     fork := true,
-    javaOptions += "-Xmx174m"
+    javaOptions += "-Xmx174m",
+    publishTo := Some(Opts.resolver.sonatypeStaging)
   )
-  .dependsOn(protostuff)
+  .enablePlugins(ProtobufPlugin)
 
 lazy val builder = (project in file("builder"))
   .settings(commonSettings)
   .settings(
-    libraryDependencies := Seq(
-      "de.grundid.opendatalab" % "geojson-jackson" % "1.8",
-      "org.apache.commons" % "commons-compress" % "1.14",
-      "org.tukaani" % "xz" % "1.6"
-    ),
+    libraryDependencies ++= Seq(
+      "de.grundid.opendatalab" % "geojson-jackson" % "1.8"
+    ) ++ sevenZSupport,
     name := "timeshape-builder",
     skip in publish := true
   )
-  .dependsOn(protostuff)
-
-lazy val protostuff = (project in file("protostuff"))
-  .settings(commonSettings)
-  .settings(skip in publish := true)
-  .enablePlugins(ProtobufPlugin)
+  .dependsOn(core)
 
 lazy val testApp = (project in file("test-app"))
   .settings(commonSettings)

--- a/builder/src/main/java/net/iakovlev/timeshape/Main.java
+++ b/builder/src/main/java/net/iakovlev/timeshape/Main.java
@@ -8,13 +8,19 @@ import org.geojson.FeatureCollection;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.IOException;
 import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.zip.ZipInputStream;
 
 public class Main {
 
-    static void writeSevenZProto(String inputPath, String outputPath) {
-        try (InputStream stream = new FileInputStream(inputPath)) {
+    static void writeSevenZProto(String version, String outputPath) {
+        String url = "https://github.com/evansiroky/timezone-boundary-builder/releases/download/" + version + "/timezones.geojson.zip";
+        try (InputStream stream = new URL(url).openStream()) {
             ZipInputStream zipInputStream = new ZipInputStream(stream);
             zipInputStream.getNextEntry();
             Geojson.FeatureCollection featureCollection = Builder.buildProto(new ObjectMapper().readValue(zipInputStream, FeatureCollection.class));
@@ -33,8 +39,8 @@ public class Main {
     }
 
     public static void main(String[] args) {
-        String inputPath = args[0];
+        String version = args[0];
         String outputPath = args[1];
-        writeSevenZProto(inputPath, outputPath);
+        writeSevenZProto(version, outputPath);
     }
 }

--- a/core/src/main/protobuf/geojson.proto
+++ b/core/src/main/protobuf/geojson.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 package net.iakovlev.timeshape.proto;
 
 message FeatureCollection {

--- a/publish.sbt
+++ b/publish.sbt
@@ -1,10 +1,3 @@
-publishTo := Some(
-  if (isSnapshot.value)
-    Opts.resolver.sonatypeSnapshots
-  else
-    Opts.resolver.sonatypeStaging
-)
-
 pomExtra in Global := {
   <url>https://github.com/RomanIakovlev/timeshape</url>
     <licenses>

--- a/test-app/src/main/java/net/iakovlev/timeshape/testapp/Main.java
+++ b/test-app/src/main/java/net/iakovlev/timeshape/testapp/Main.java
@@ -4,7 +4,7 @@ import net.iakovlev.timeshape.TimeZoneEngine;
 
 public class Main {
     static public void main(String[] args) {
-        TimeZoneEngine engine = TimeZoneEngine.initialize(4.8237, 47.0599, 15.2486, 55.3300);
+        TimeZoneEngine engine = TimeZoneEngine.initialize(47.0599, 4.8237, 55.3300, 15.2486);
         System.out.println(engine.query(52.52, 13.40));
     }
 }


### PR DESCRIPTION
Releasing the `2018d.3` to fix the https://github.com/RomanIakovlev/timeshape/issues/2. The problem was caused, in short, by the not the most convenient build setup.

Particularly, I wanted to have an independent project in the build containing only protobuf definitions and generated java files. Such approach, however, requires publishing the artifact of the pure protobuf project in addition to the main artifact of `timeshape`. This is not something I'd like to do, because from user's perspective that protobuf artifact is purely an implementation detail, and doesn't bring anything useful on its own.

Now the build structure is such that protobuf definitions are bundled with the main (`core`) project, and `timeshape-builder` project depends on `core`, instead of having separate protobuf project.  Since the `timeshape-builder` is not published anyway, it's not important for it to have minimal dependency set.

Additionally, modified the builder application to download the source data directly, instead of relying on it being already downloaded on the disk, plus some other minor changes.