### PR TITLE
Resolves https://github.com/RomanIakovlev/timeshape/issues/6

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -8,7 +8,9 @@
 > ― **Albert Einstein**
 
 Timeshape is a Java library that can be used to determine to which time zone a given geo coordinate belongs.
-It's based on data published at [https://github.com/evansiroky/timezone-boundary-builder/releases](https://github.com/evansiroky/timezone-boundary-builder/releases).
+It's based on data published at 
+[https://github.com/evansiroky/timezone-boundary-builder/releases](https://github.com/evansiroky/timezone-boundary-builder/releases),
+which itself is inherited from the OpenStreetMap data.
 
 ## Getting started
 
@@ -50,10 +52,14 @@ Optional<ZoneId> maybeZoneId = engine.query(52.52, 13.40);
 ``` 
 
 #### Memory usage
-This library requires roughly 179 megabytes of heap memory to parse the geometry data and build index for the whole world.
+This library requires roughly 179 megabytes of heap memory to parse the geometry data and build index for the whole world 
+when running the tests.
 This is reflected in the configuration of Java options in `core` sbt project, to track if memory usage will increase in future.
 It is possible to further limit the memory usage by reducing the amount of time zones loaded. This is implemented by a call to
 `TimeZoneEngine.initialize(double minlat, double minlon, double maxlat, double maxlon)`
+
+The `testApp` project provides a more precise memory usage estimate by using [JOL](http://openjdk.java.net/projects/code-tools/jol/).
+The current version's estimated footprint is roughly 128 MB of memory when the data for the whole world is loaded.
 
 ## Versioning
 Version of Timeshape consist of data version and software version, divided by a '.' symbol. 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ val dataVersion = "2018d"
 val softwareVersion = "4"
 val sevenZSupport = Seq(
   "org.apache.commons" % "commons-compress" % "1.14",
-  "org.tukaani" % "xz" % "1.6",
+  "org.tukaani" % "xz" % "1.6"
 )
 val commonSettings = Seq(
   organization := "net.iakovlev",
@@ -49,5 +49,7 @@ lazy val testApp = (project in file("test-app"))
   .settings(commonSettings)
   .settings(
     mainClass in assembly := Some("net.iakovlev.timeshape.testapp.Main"),
-    skip in publish := true)
+    skip in publish := true,
+    libraryDependencies += "org.openjdk.jol" % "jol-core" % "0.9"
+  )
   .dependsOn(core)

--- a/test-app/src/main/java/net/iakovlev/timeshape/testapp/Main.java
+++ b/test-app/src/main/java/net/iakovlev/timeshape/testapp/Main.java
@@ -1,10 +1,19 @@
 package net.iakovlev.timeshape.testapp;
 
 import net.iakovlev.timeshape.TimeZoneEngine;
+import org.openjdk.jol.info.GraphLayout;
+import org.openjdk.jol.vm.VM;
+
+import static java.lang.System.out;
 
 public class Main {
     static public void main(String[] args) {
-        TimeZoneEngine engine = TimeZoneEngine.initialize(47.0599, 4.8237, 55.3300, 15.2486);
-        System.out.println(engine.query(52.52, 13.40));
+        long start = System.currentTimeMillis();
+        TimeZoneEngine engine = TimeZoneEngine.initialize();
+        long total = System.currentTimeMillis() - start;
+        out.println("initialization took " + total + " milliseconds");
+        out.println(engine.query(52.52, 13.40));
+        out.println(VM.current().details());
+        out.println(GraphLayout.parseInstance(engine).toFootprint());
     }
 }


### PR DESCRIPTION
Use JOL in testApp to better estimate the memory usage of TimeZoneEngine,
update the readme with findings (128 MB currently for the whole world).