### PR TITLE
build.sbt: get latest timezone-boundary-builder release from api.github.com

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
 import scala.sys.process._
+import scala.util.parsing.json._
 
 val dataVersion = "2019b"
 val softwareVersion = "7-SNAPSHOT"
@@ -27,10 +28,24 @@ lazy val builderArgument = settingKey[String](
 lazy val releaseTask = taskKey[Unit](
   "Publishes an artifact and optionally makes a release if version is not a snapshot")
 
+def latestRelease: String = {
+  val src = scala.io.Source.fromURL("https://api.github.com/repos/evansiroky/timezone-boundary-builder/releases/latest")
+  val json = src.mkString
+  json
+}
+
+def parseReleaseName(jsonString: String): String = {
+  val json:Option[Any] = JSON.parseFull(jsonString)
+  val map:Map[String,Any] = json.get.asInstanceOf[Map[String, Any]]
+  val name:String = map("name").asInstanceOf[String]
+  println("Current timezone release is : " + name)
+  name
+}
+
 lazy val core = (project in file("core"))
   .settings(commonSettings)
   .settings(
-    builderArgument := dataVersion,
+    builderArgument := parseReleaseName(latestRelease),
     libraryDependencies ++= Seq(
       "com.esri.geometry" % "esri-geometry-api" % "2.2.1",
       "junit" % "junit" % "4.12" % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -56,13 +56,12 @@ lazy val core = (project in file("core"))
       if (!outputFile.exists()) {
         log.info("Timeshape resource doesn't exist in this host, creating it now.")
         val jsonString = getLatestRelease
-        val latest: String = _root_.io.circe.parser.parse(jsonString)
+        val latest: String = io.circe.parser.parse(jsonString)
           .flatMap(_.hcursor.downField("name").as[String])
           .getOrElse("Unknown")
-        if (latest == builderArgument.value)
-          log.info("Latest timezone data release is : " + latest)
-        else
-          log.warn("Latest timezone data release is : " + latest)
+        if (latest != builderArgument.value) {
+          log.warn(s"Latest timezone data release is : $latest, while this build uses ${builderArgument.value}")
+        }
         log.info("Downloading timezone data with version: " + builderArgument.value)
         val command =
           s"java -jar ${(builder / assembly).value} ${builderArgument.value} ${outputFile.getAbsolutePath}"

--- a/build.sbt
+++ b/build.sbt
@@ -91,12 +91,6 @@ lazy val `geojson-proto` = (project in file("geojson-proto"))
     )
   )
 
-val sampleStringTask = taskKey[String]("A sample string task.")
-
-lazy val library = (project in file("library"))
-  .settings(
-    sampleStringTask := System.getProperty("user.home")
-  )
 
 lazy val builder = (project in file("builder"))
   .settings(commonSettings)

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
 import scala.sys.process._
+import _root_.io.circe.parser._
 
 val dataVersion = "2019b"
 val softwareVersion = "7-SNAPSHOT"
@@ -56,7 +57,7 @@ lazy val core = (project in file("core"))
       if (!outputFile.exists()) {
         log.info("Timeshape resource doesn't exist in this host, creating it now.")
         val jsonString = getLatestRelease
-        val latest: String = io.circe.parser.parse(jsonString)
+        val latest: String = parse(jsonString)
           .flatMap(_.hcursor.downField("name").as[String])
           .getOrElse("Unknown")
         if (latest != builderArgument.value) {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,3 +7,4 @@ addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.4")
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.25")
 
 libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.9.0"
+libraryDependencies += "io.circe" %% "circe-parser" % "0.12.2"


### PR DESCRIPTION
build.sbt: get latest timezone-boundary-builder release from api.github.com

Add a helper for determining the latest release version of repository evansiroky/timezone-boundary-builder using Rest API at api.github.com.

The version of timeshape continues to be hardcoded in build.sbt.