### PR TITLE
Fix: Index.queryPolyline does not return last empty SameZoneSpan

### DIFF
--- a/core/src/main/java/net/iakovlev/timeshape/Index.java
+++ b/core/src/main/java/net/iakovlev/timeshape/Index.java
@@ -115,6 +115,10 @@ final class Index {
             }
         }
 
+        if (lastWasEmpty) {
+            sameZoneSegments.add(SameZoneSpan.fromIndexEntries(Collections.emptyList(), index * 2 - 1));
+        }
+
         return sameZoneSegments;
     }
 

--- a/core/src/test/java/net/iakovlev/timeshape/TimeZoneEnginePolylineTest.java
+++ b/core/src/test/java/net/iakovlev/timeshape/TimeZoneEnginePolylineTest.java
@@ -52,4 +52,14 @@ public class TimeZoneEnginePolylineTest {
                         new SameZoneSpan(new HashSet<>(Collections.singletonList(ZoneId.of("Etc/GMT-1"))), 11),
                         new SameZoneSpan(new HashSet<>(Collections.singletonList(ZoneId.of("Europe/Stockholm"))), 13)));
     }
+
+    @Test
+    public void testNonMatchingLastPoints() {
+        assertEquals(engine.queryPolyline(new double[]{54.89, 23.91, 55.13, 25.57, 54.29, 28.32, 80, 180, 80, 180}),
+                Arrays.asList(
+                        new SameZoneSpan(new HashSet<>(Collections.singletonList(ZoneId.of("Europe/Vilnius"))), 3),
+                        new SameZoneSpan(new HashSet<>(Collections.singletonList(ZoneId.of("Europe/Minsk"))), 5),
+                        new SameZoneSpan(new HashSet<>(), 9)
+                ));
+    }
 }


### PR DESCRIPTION
Fix: Last SameZoneSpan instance was not included in the result of Index.queryPolyline, when one or more end points of polyline did not belong to any of time zones in the index.