### PR TITLE
Rollback sbt version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: scala
 
-dist: trusty
-
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 script: .travis/build.sh
 

--- a/core/src/test/java/net/iakovlev/timeshape/TimeZoneEngineOutfileBoundedTest.java
+++ b/core/src/test/java/net/iakovlev/timeshape/TimeZoneEngineOutfileBoundedTest.java
@@ -38,6 +38,6 @@ public class TimeZoneEngineOutfileBoundedTest {
     @Test
     public void testWorld() {
         List<ZoneId> knownZoneIds = engine.getKnownZoneIds();
-        assertEquals(1401, knownZoneIds.size());
+        assertEquals(1402, knownZoneIds.size());
     }
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.5
+sbt.version=1.3.13


### PR DESCRIPTION
It looks like the issue with zero timestamps of JAR entries is first introduced in sbt 1.4.0. Sbt 1.3.13 is the last one not causing this problem. Also rollback the CI changes (JDK, OS), because they're not relevant.