### PR TITLE
Get rid of jackson-core at runtime

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,6 @@ lazy val core = (project in file("core"))
       "com.novocode" % "junit-interface" % "0.11" % Test
         exclude ("junit", "junit-dep"),
       "org.slf4j" % "slf4j-api" % "1.7.30",
-      "com.fasterxml.jackson.core" % "jackson-core" % "2.12.0",
       "net.iakovlev" % "geojson-proto" % "1.1.0"
     ) ++ `commons-compress`,
     name := "timeshape",


### PR DESCRIPTION
from what I can tell, timeshape only needs `jackson-core` at compile time (in the builder project), where it parses actual json which it then serialized to protobuf format.

the final `timeshape.jar` no longer needs jackson: its bundled `data.tar.zstd` is in protobuf format understood by `geojson-proto` (which itself also doesn't need jackson, but only protobuf and commons-compress to parse that data).

the change in this PR should result in a .pom that does not list jackson-core as dependency.