### PR TITLE
Bump up protobuf and sbt_protoc versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -86,7 +86,7 @@ lazy val `geojson-proto` = (project in file("geojson-proto"))
     publishTo := sonatypePublishTo.value,
     version := "1.1.1-SNAPSHOT",
     PB.targets in Compile := Seq(
-      PB.gens.java("3.19.2") -> (sourceManaged in Compile).value
+      PB.gens.java("3.21.9") -> (sourceManaged in Compile).value
     ),
     javacOptions ++= Seq("-Xdoclint:none"),
     releaseTask := {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ addSbtPlugin("io.crashbox" % "sbt-gpg" % "0.2.1")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.4")
-addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.25")
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.34")
 
 libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.9.0"
 libraryDependencies += "io.circe" %% "circe-parser" % "0.12.2"


### PR DESCRIPTION
This is to address:
Vulnerabilities from dependencies:
[CVE-2022-3171](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3171)
[CVE-2021-22569](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-22569)

See issue: https://github.com/RomanIakovlev/timeshape/issues/103