### PR TITLE
Release 2022g.16

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -24,14 +24,14 @@ Timeshape is published on Maven Central. The coordinates are the following:
 <dependency>
     <groupId>net.iakovlev</groupId>
     <artifactId>timeshape</artifactId>
-    <version>2022f.15</version>
+    <version>2022g.16</version>
 </dependency>
 ``` 
 
 ## Android
 Android developers should add Timeshape to the app level gradle.build as follows:
 ```
-implementation('net.iakovlev:timeshape:2022f.15') {
+implementation('net.iakovlev:timeshape:2022g.16') {
   // Exclude standard compression library
   exclude group: 'com.github.luben', module: 'zstd-jni'
 }

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
 import scala.sys.process._
 import _root_.io.circe.parser._
 
-val dataVersion = "2022f"
-val softwareVersion = "15"
+val dataVersion = "2022g"
+val softwareVersion = "16"
 val `commons-compress` = Seq(
   "org.apache.commons" % "commons-compress" % "1.21",
   "com.github.luben" % "zstd-jni" % "1.5.2-3"


### PR DESCRIPTION
New release to update the latest version of [the dataset](https://github.com/evansiroky/timezone-boundary-builder/releases/tag/2022g)