### PR TITLE
upgrade data to version 2023b from  evansiroky/timezone-boundary-builder

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -5,13 +5,15 @@
 [![Gitter](https://badges.gitter.im/timeshape/community.svg)](https://gitter.im/timeshape/community)
 
 Timeshape is a Java library that can be used to determine to which time zone a given geo coordinate belongs.
-It's based on data published at 
+It's based on data published at
 [https://github.com/evansiroky/timezone-boundary-builder/releases](https://github.com/evansiroky/timezone-boundary-builder/releases),
 which itself is inherited from the OpenStreetMap data.
 
 But what if knowing just time zone for a geo coordinate is not enough? Wouldn't it be nice to know more, like
-administrative area or city neighborhood? Check out [GeoBundle](https://geobundle.com), now there's a Java library for that, too! 
+administrative area or city neighborhood? Check out [GeoBundle](https://geobundle.com), now there's a Java library for that, too!
+
 ## Quote
+
 > “Time is an illusion.”
 >
 > ― **Albert Einstein**
@@ -24,14 +26,16 @@ Timeshape is published on Maven Central. The coordinates are the following:
 <dependency>
     <groupId>net.iakovlev</groupId>
     <artifactId>timeshape</artifactId>
-    <version>2022g.17</version>
+    <version>2023b.18</version>
 </dependency>
-``` 
+```
 
 ## Android
+
 Android developers should add Timeshape to the app level gradle.build as follows:
-```
-implementation('net.iakovlev:timeshape:2022g.17') {
+
+```gradle
+implementation('net.iakovlev:timeshape:2023b.18') {
   // Exclude standard compression library
   exclude group: 'com.github.luben', module: 'zstd-jni'
 }
@@ -48,21 +52,26 @@ Are you using Timeshape? Please consider opening a pull request to list your org
 ## Using the library
 
 The user API of library is in `net.iakovlev.timeshape.TimeZoneEngine` class. To use it, follow these steps:
-    
+
 #### Initialization
+
 Initialize the class with the data for the whole world:
+
 ```java
 import net.iakovlev.timeshape.TimeZoneEngine;
 TimeZoneEngine engine = TimeZoneEngine.initialize();
 ```
+
 Or, alternatively, initialize it with some bounding box only, to reduce memory usage:
+
 ```java
 TimeZoneEngine engine = TimeZoneEngine.initialize(47.0599, 4.8237, 55.3300, 15.2486);
 ```
+
 It is important to mention that for the time zone to be loaded by the second method,
 it must be covered by the bounding box completely, not just intersect with it.
 
-During initialization, the data is read from resource and the index is built. 
+During initialization, the data is read from resource and the index is built.
 Initialization takes a significant amount of time (approximately 1 second), so do it only once in program lifetime.
 
 Data can also be read from an external file, see overloads of `TimeZoneEngine.initialize` that accept
@@ -71,15 +80,17 @@ Data can also be read from an external file, see overloads of `TimeZoneEngine.in
 It is responsibility of caller to close input stream passed to `TimeZoneEngine.initialize`.
 
 #### Query for `java.time.ZoneId`:
+
 Once initialization is completed, you can query the `ZoneId` based on latitude and longitude:
 
 ```java
 import java.util.Optional;
 import java.time.ZoneId;
 Optional<ZoneId> maybeZoneId = engine.query(52.52, 13.40);
-``` 
+```
 
 #### Multiple time zones for single geo point
+
 Starting from release 2019b.7, the data source from which Timeshape is built contains overlapping geometries.
 In other words, some geo points can simultaneously belong to multiple time zones. To accommodate this,
 Timeshape has made the following change. It's now possible to query all the time zones, to which given
@@ -91,18 +102,20 @@ List<ZoneId> allZones = engine.queryAll(52.52, 13.40);
 
 The `Optional<ZoneId> query(double latitude, double longitude)` method is still there, and it still returns
 maximum one `ZoneId`. If given geo point belongs to multiple time zones, only single one will be returned.
-Which of multiple zones will be returned is entirely arbitrary. Because of this, method 
-`Optional<ZoneId> query(double latitude, double longitude)` is not suitable for use cases where such choice must 
+Which of multiple zones will be returned is entirely arbitrary. Because of this, method
+`Optional<ZoneId> query(double latitude, double longitude)` is not suitable for use cases where such choice must
 be deliberate. In such cases use `List<ZoneId> queryAll(double latitude, double longitude)` method and apply further
-business logic to its output to choose the right time zone. Consult file 
+business logic to its output to choose the right time zone. Consult file
 https://raw.githubusercontent.com/evansiroky/timezone-boundary-builder/master/expectedZoneOverlaps.json
 for information about areas of the world where multiple time zones are to be expected.
 
 #### Querying polyline
+
 Timeshape supports querying of multiple sequential geo points (a polyline, e.g. a GPS trace) in an optimized way using method
 `List<SameZoneSpan> queryPolyline(double[] points)`. Performance tests (see `net.iakovlev.timeshape.PolylineQueryBenchmark`)
 show significant speedup of using this method for querying a polyline, comparing to separately querying each point from polyline 
 using `Optional<ZoneId> query(double latitude, double longitude)` method:
+
 ```
 Benchmark                                  Mode  Cnt  Score   Error  Units
 PolylineQueryBenchmark.testQueryPoints    thrpt    5  2,188 ▒ 0,044  ops/s
@@ -110,11 +123,13 @@ PolylineQueryBenchmark.testQueryPolyline  thrpt    5  4,073 ▒ 0,017  ops/s
 ```
 
 ### Architecture
+
 See [dedicated document](doc/Architecture.md) for description of Timeshape internals.
 
 ### Versioning
-Version of Timeshape consist of data version and software version, divided by a '.' symbol. 
-Data version is as specified at [https://github.com/evansiroky/timezone-boundary-builder/releases](https://github.com/evansiroky/timezone-boundary-builder/releases). 
+
+Version of Timeshape consist of data version and software version, divided by a '.' symbol.
+Data version is as specified at [https://github.com/evansiroky/timezone-boundary-builder/releases](https://github.com/evansiroky/timezone-boundary-builder/releases).
 Software version is an integer, starting from 1 and incrementing for each published artifact.
 
 ## Licenses

--- a/build.sbt
+++ b/build.sbt
@@ -2,19 +2,23 @@ import scala.sys.process._
 import _root_.io.circe.parser._
 
 val dataVersion = "2023b"
-val softwareVersion = "18-SNAPSHOT"
+val softwareVersion = "18"
+val snapshotRelease = false
+
+val releaseType = if (snapshotRelease) "-SNAPSHOT" else ""
+
+val commonSettings = Seq(
+  organization := "net.iakovlev",
+  sonatypeProfileName := "net.iakovlev",
+  version := s"$dataVersion.$softwareVersion$releaseType",
+  crossPaths := false,
+  autoScalaLibrary := false,
+  publishMavenStyle := true
+)
 
 val `commons-compress` = Seq(
   "org.apache.commons" % "commons-compress" % "1.22",
   "com.github.luben" % "zstd-jni" % "1.5.2-5"
-)
-val commonSettings = Seq(
-  organization := "net.iakovlev",
-  sonatypeProfileName := "net.iakovlev",
-  version := s"$dataVersion.$softwareVersion",
-  crossPaths := false,
-  autoScalaLibrary := false,
-  publishMavenStyle := true
 )
 
 lazy val timeshape = (project in file("."))

--- a/build.sbt
+++ b/build.sbt
@@ -4,8 +4,6 @@ import _root_.io.circe.parser._
 val dataVersion = "2023b"
 val softwareVersion = "18-SNAPSHOT"
 
-scalacOptions += "-target:jvm-1.8"
-
 val `commons-compress` = Seq(
   "org.apache.commons" % "commons-compress" % "1.22",
   "com.github.luben" % "zstd-jni" % "1.5.2-5"

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import scala.sys.process._
 import _root_.io.circe.parser._
 
-val dataVersion = "2022g"
+val dataVersion = "2023b"
 val softwareVersion = "18-SNAPSHOT"
 
 scalacOptions += "-target:jvm-1.8"

--- a/doc/Architecture.md
+++ b/doc/Architecture.md
@@ -77,6 +77,7 @@ changes of time zones happen regularly in real world, and only the latest JDK bu
 Version must be set to `snapshot` for local publication to work best.
 
 ### local testing
+
 If you want to use a modified version of timeshape in your program or perform some local testing include the local
 repository in your build definition.
 
@@ -95,11 +96,12 @@ repositories {
 }
 
 dependencies {
-    compile group: 'net.iakovlev', name: 'timeshape', version: '2019b.7-SNAPSHOT'
+    compile group: 'net.iakovlev', name: 'timeshape', version: '2023b.18-SNAPSHOT'
 }
 ```
 
 ## Memory usage
+
 The `testApp` project provides memory usage estimate by using [JOL](http://openjdk.java.net/projects/code-tools/jol/).
 The current version's estimated footprint is roughly 128 MB of memory when the data for the whole world is loaded.
 It is possible to further limit the memory usage by reducing the amount of time zones loaded. This is implemented by a call to


### PR DESCRIPTION
### Changes

- Upgraded data to version [2023b](https://github.com/evansiroky/timezone-boundary-builder/releases/tag/2023b)
- Updated version in the readme and docs