### PR TITLE
Update zstd-jni to 1.5.5-11

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -51,6 +51,7 @@ implementation 'com.github.luben:zstd-jni:1.5.5-11@aar'
 Are you using Timeshape? Please consider opening a pull request to list your organization here:
 
  * Name and website of your organization
+ * [Hopper](https://hopper.com/)
 
 ## Using the library
 

--- a/README.MD
+++ b/README.MD
@@ -43,7 +43,7 @@ implementation('net.iakovlev:timeshape:2023b.20') {
   exclude group: 'com.github.luben', module: 'zstd-jni'
 }
 // Import aar for native component compilation
-implementation 'com.github.luben:zstd-jni:1.5.5-6@aar'
+implementation 'com.github.luben:zstd-jni:1.5.5-11@aar'
 ```
 
 ## Adopters

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ val commonSettings = Seq(
 
 val `commons-compress` = Seq(
   "org.apache.commons" % "commons-compress" % "1.24.0",
-  "com.github.luben" % "zstd-jni" % "1.5.5-6"
+  "com.github.luben" % "zstd-jni" % "1.5.5-11"
 )
 
 lazy val timeshape = (project in file("."))


### PR DESCRIPTION
Hi! We (at [Hopper](https://hopper.com/)) use timeshape in a few of our Scala microservices. I was working on some dependency updates and was getting some binary compatibility warnings with `zstd-jni`. I am *fairly* certain `1.5.5-11` and `1.5.5-6` are binary compatible, but it would be nice to get this bumped to latest if its not too much work to get a new release published. I saw master was bumped to `2023b.21-SNAPSHOT`, so not sure if that release will be good to go or if other changes will also be needed.

Thank you for maintaining the project! Let me know if I missed anything.