### PR TITLE
Release 2024a.22

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -26,7 +26,7 @@ Timeshape is published on Maven Central. The coordinates are the following:
 <dependency>
     <groupId>net.iakovlev</groupId>
     <artifactId>timeshape</artifactId>
-    <version>2023b.21</version>
+    <version>2024a.22</version>
 </dependency>
 ```
 

--- a/README.MD
+++ b/README.MD
@@ -38,7 +38,7 @@ but now it's brought back.
 Android developers should add Timeshape to the app level gradle.build as follows:
 
 ```gradle
-implementation('net.iakovlev:timeshape:2023b.21') {
+implementation('net.iakovlev:timeshape:2024a.22') {
   // Exclude standard compression library
   exclude group: 'com.github.luben', module: 'zstd-jni'
 }

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import _root_.io.circe.parser._
 
 val dataVersion = "2024a"
 val softwareVersion = "22"
-val snapshotRelease = true
+val snapshotRelease = false
 
 val releaseType = if (snapshotRelease) "-SNAPSHOT" else ""
 


### PR DESCRIPTION
Bump the data version and fix https://github.com/RomanIakovlev/timeshape/issues/140.