### PR TITLE
chore: update protobuf dependency to fix vulnerability

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -82,7 +82,7 @@ lazy val `geojson-proto` = (project in file("geojson-proto"))
     publishTo := sonatypePublishTo.value,
     version := "1.1.4-SNAPSHOT",
     Compile / PB.targets := Seq(
-      PB.gens.java("3.21.12") -> (Compile / sourceManaged).value
+      PB.gens.java("3.25.5") -> (Compile / sourceManaged).value
     ),
     Compile / doc / javacOptions := Seq("-Xdoclint:none"),
     Compile / javacOptions := Seq("-source", "8", "-target", "8"),


### PR DESCRIPTION
There was a vulnerability detected in the protobuf library. [https://nvd.nist.gov/vuln/detail/CVE-2024-7254](https://nvd.nist.gov/vuln/detail/CVE-2024-7254)
Fixed with  [version 3.25.5](https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java)