### PR TITLE
Update to Protobuf 4.29.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -82,8 +82,9 @@ lazy val `geojson-proto` = (project in file("geojson-proto"))
     publishTo := sonatypePublishTo.value,
     version := "1.1.5-SNAPSHOT",
     Compile / PB.targets := Seq(
-      PB.gens.java("3.25.5") -> (Compile / sourceManaged).value
+      PB.gens.java("4.29.3") -> (Compile / sourceManaged).value
     ),
+    PB.protocVersion := "4.29.3",
     Compile / doc / javacOptions := Seq("-Xdoclint:none"),
     Compile / javacOptions := Seq("-source", "8", "-target", "8"),
     releaseTask := {

--- a/geojson-proto/src/main/protobuf/geojson.proto
+++ b/geojson-proto/src/main/protobuf/geojson.proto
@@ -1,4 +1,4 @@
-syntax = "proto2";
+syntax = "proto3";
 
 package net.iakovlev.timeshape.proto;
 
@@ -7,12 +7,12 @@ message FeatureCollection {
 }
 
 message Feature {
-    required Geometry geometry = 1;
+    Geometry geometry = 1;
     repeated Property properties = 2;
 }
 
 message Point {
-    required Position coordinates = 1;
+    Position coordinates = 1;
 }
 
 message MultiPoint {
@@ -40,8 +40,8 @@ message GeometryCollection {
 }
 
 message Position {
-    required float lon = 1;
-    required float lat = 2;
+    float lon = 1;
+    float lat = 2;
 }
 
 message Geometry {
@@ -57,7 +57,7 @@ message Geometry {
 }
 
 message Property {
-    required string key = 1;
+    string key = 1;
     oneof value {
         string valueString = 2;
         double valueNumber = 3;

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,8 +3,8 @@ resolvers += Resolver.jcenterRepo
 addSbtPlugin("io.crashbox" % "sbt-gpg" % "0.2.1")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.4")
-addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.0")
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.7")
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.13")
 
-libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.14"
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.17"
 libraryDependencies += "io.circe" %% "circe-parser" % "0.12.2"


### PR DESCRIPTION
Update the protobuf library and protoc to 4.29.3. Updated sbt-protoc to 1.0.7 and compilerplugin to 0.11.17.

I updated the proto file in geojson-proto to use proto3 syntax. The changes were minimal, only the `required` flag had to be dropped since it isn't needed anymore.

All tests passed with the updates but I had to modify the build script locally to get the updated geojson-proto library to be used by the core library. \
![image](https://github.com/user-attachments/assets/7155023e-3716-400e-b9fa-8720be4c5393)

jackson-core, commons-compress, and zstd-jni can be updated without breaking anything internal to this library but I didn't include them as part of this pull request.