### PR TITLE
Release geojson-proto 1.1.6 and Timeshape 2025b.28

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.iakovlev</groupId>
         <artifactId>timeshape-parent</artifactId>
-        <version>2025b.27</version>
+        <version>2025b.28</version>
     </parent>
 
     <artifactId>timeshape-benchmarks</artifactId>

--- a/builder/pom.xml
+++ b/builder/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.iakovlev</groupId>
         <artifactId>timeshape-parent</artifactId>
-        <version>2025b.27</version>
+        <version>2025b.28</version>
     </parent>
 
     <artifactId>timeshape-builder</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.iakovlev</groupId>
         <artifactId>timeshape-parent</artifactId>
-        <version>2025b.27</version>
+        <version>2025b.28</version>
     </parent>
 
     <artifactId>timeshape</artifactId>

--- a/geojson-proto/pom.xml
+++ b/geojson-proto/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.iakovlev</groupId>
         <artifactId>timeshape-parent</artifactId>
-        <version>2025b.27</version>
+        <version>2025b.28</version>
     </parent>
 
     <properties>
@@ -15,7 +15,7 @@
     </properties>
 
     <artifactId>geojson-proto</artifactId>
-    <version>1.1.6-SNAPSHOT</version>
+    <version>1.1.6</version>
     <packaging>jar</packaging>
 
     <name>GeoJSON Proto</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.iakovlev</groupId>
     <artifactId>timeshape-parent</artifactId>
-    <version>2025b.27</version>
+    <version>2025b.28</version>
     <packaging>pom</packaging>
 
     <name>Timeshape Parent</name>
@@ -73,7 +73,7 @@
             <dependency>
                 <groupId>net.iakovlev</groupId>
                 <artifactId>geojson-proto</artifactId>
-                <version>1.1.6-SNAPSHOT</version>
+                <version>1.1.6</version>
             </dependency>
             <dependency>
                 <groupId>net.iakovlev</groupId>

--- a/test-app/pom.xml
+++ b/test-app/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.iakovlev</groupId>
         <artifactId>timeshape-parent</artifactId>
-        <version>2025b.27</version>
+        <version>2025b.28</version>
     </parent>
 
     <artifactId>timeshape-testapp</artifactId>


### PR DESCRIPTION
Timeshare release is just to fix the previous dependency on a snapshot version of geojson-core. I'm making both geojson-proto and Timeshare releases in one PR, not sure if this will work, but one can hope.

Related issue: https://github.com/RomanIakovlev/timeshape/issues/136