### PR TITLE
Initialize with a list of ZoneIds. Fixes #180

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -77,6 +77,15 @@ TimeZoneEngine engine = TimeZoneEngine.initialize(47.0599, 4.8237, 55.3300, 15.2
 It is important to mention that for the time zone to be loaded by the second method,
 it must be covered by the bounding box completely, not just intersect with it.
 
+if you have difficulty determining the bounding box, you may prefer to use a list of ZoneIds instead.
+```Java
+ArrayList<ZoneId> timeZones = new ArrayList<> ();
+timeZones.add(ZoneId.of("Europe/Berlin"));
+timeZones.add(ZoneId.of("America/Detroit"));
+TimeZoneEngine engine = TimeZoneEngine.initialize (timeZones, true);
+
+```
+
 During initialization, the data is read from resource and the index is built.
 Initialization takes a significant amount of time (approximately 1 second), so do it only once in program lifetime.
 
@@ -141,7 +150,7 @@ for information about areas of the world where multiple time zones are to be exp
 
 Timeshape supports querying of multiple sequential geo points (a polyline, e.g. a GPS trace) in an optimized way using method
 `List<SameZoneSpan> queryPolyline(double[] points)`. Performance tests (see `net.iakovlev.timeshape.PolylineQueryBenchmark`)
-show significant speedup of using this method for querying a polyline, comparing to separately querying each point from polyline 
+show significant speedup of using this method for querying a polyline, comparing to separately querying each point from polyline
 using `Optional<ZoneId> query(double latitude, double longitude)` method:
 
 ```

--- a/README.MD
+++ b/README.MD
@@ -79,7 +79,7 @@ it must be covered by the bounding box completely, not just intersect with it.
 
 if you have difficulty determining the bounding box, you may prefer to use a list of ZoneIds instead.
 ```Java
-ArrayList<ZoneId> timeZones = new ArrayList<> ();
+Set<ZoneId> timeZones = new HashSet<> ();
 timeZones.add(ZoneId.of("Europe/Berlin"));
 timeZones.add(ZoneId.of("America/Detroit"));
 TimeZoneEngine engine = TimeZoneEngine.initialize (timeZones, true);

--- a/core/src/main/java/net/iakovlev/timeshape/Index.java
+++ b/core/src/main/java/net/iakovlev/timeshape/Index.java
@@ -209,8 +209,8 @@ final class Index implements Serializable {
             String zoneIdName = f.getProperties(0).getValueString();
             try {
                 ZoneId zoneId = ZoneId.of(zoneIdName);
-                getPolygons(f).forEach(polygon -> {
-                    if (timeZones.contains (zoneId)) {
+                if (timeZones.contains (zoneId)) {
+                    getPolygons(f).forEach(polygon -> {
                         log.debug("Adding zone {} to index", zoneIdName);
                         if (accelerateGeometry) {
                             operatorIntersects.accelerateGeometry(polygon, spatialReference, Geometry.GeometryAccelerationDegree.enumMild);
@@ -219,10 +219,10 @@ final class Index implements Serializable {
                         int index = indices.next();
                         quadTree.insert(index, env);
                         zoneIds.add(index, new Entry(zoneId, polygon));
-                    } else {
-                        log.debug("Not adding zone {} to index because it's out of provided boundaries", zoneIdName);
-                    }
-                });
+                    });
+                } else {
+                    log.debug("Not adding zone {} to index because it's out of provided boundaries", zoneIdName);
+                }
             } catch (Exception ex) {
                 unknownZones.add(zoneIdName);
             }

--- a/core/src/main/java/net/iakovlev/timeshape/Index.java
+++ b/core/src/main/java/net/iakovlev/timeshape/Index.java
@@ -10,7 +10,9 @@ import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.PrimitiveIterator;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -195,7 +197,7 @@ final class Index implements Serializable {
 
     
     @SuppressWarnings("SizeReplaceableByIsEmpty")
-    static Index build(Stream<Geojson.Feature> features, int size, List<ZoneId> timeZones, boolean accelerateGeometry) {
+    static Index build(Stream<Geojson.Feature> features, int size, Set<ZoneId> timeZones, boolean accelerateGeometry) {
         Envelope2D boundariesEnvelope = new Envelope2D();
         Envelope boundaries = new Envelope(-180, -90, 180, +90);// (minLon, minLat, maxLon, maxLat);
         boundaries.queryEnvelope2D(boundariesEnvelope);

--- a/core/src/test/java/net/iakovlev/timeshape/TimeZoneEngineBoundedTest.java
+++ b/core/src/test/java/net/iakovlev/timeshape/TimeZoneEngineBoundedTest.java
@@ -22,6 +22,6 @@ public class TimeZoneEngineBoundedTest {
     @Test
     public void testWorld() {
         List<ZoneId> knownZoneIds = engine.getKnownZoneIds();
-        assertEquals(knownZoneIds.size(), 39);
+        assertEquals(39, knownZoneIds.size());
     }
 }

--- a/core/src/test/java/net/iakovlev/timeshape/TimeZoneEngineBoundedTest.java
+++ b/core/src/test/java/net/iakovlev/timeshape/TimeZoneEngineBoundedTest.java
@@ -12,7 +12,7 @@ import static junit.framework.TestCase.assertEquals;
 
 @RunWith(JUnit4.class)
 public class TimeZoneEngineBoundedTest {
-    private static TimeZoneEngine engine = TimeZoneEngine.initialize(47.0599, 4.8237, 55.3300, 15.2486, true);
+    private static final TimeZoneEngine engine = TimeZoneEngine.initialize(47.0599, 4.8237, 55.3300, 15.2486, true);
 
     @Test
     public void testSomeZones() {

--- a/core/src/test/java/net/iakovlev/timeshape/TimeZoneEngineBoundedZoneTest.java
+++ b/core/src/test/java/net/iakovlev/timeshape/TimeZoneEngineBoundedZoneTest.java
@@ -5,8 +5,9 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import java.time.ZoneId;
-import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 
 import static junit.framework.TestCase.assertEquals;
 
@@ -15,9 +16,9 @@ public class TimeZoneEngineBoundedZoneTest {
 
     @Test
     public void testSomeZones() {
-        ArrayList<ZoneId> timeZones = new ArrayList<> ();
+        Set<ZoneId> timeZones = new HashSet<> ();
         timeZones.add (ZoneId.of("Europe/Berlin"));
-         TimeZoneEngine engine = TimeZoneEngine.initialize (timeZones, true);
+        TimeZoneEngine engine = TimeZoneEngine.initialize (timeZones, true);
         assertEquals(Optional.of(ZoneId.of("Europe/Berlin")), engine.query(52.52, 13.40));
         
         timeZones.clear ();

--- a/core/src/test/java/net/iakovlev/timeshape/TimeZoneEngineBoundedZoneTest.java
+++ b/core/src/test/java/net/iakovlev/timeshape/TimeZoneEngineBoundedZoneTest.java
@@ -1,0 +1,32 @@
+package net.iakovlev.timeshape;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Optional;
+
+import static junit.framework.TestCase.assertEquals;
+
+@RunWith(JUnit4.class)
+public class TimeZoneEngineBoundedZoneTest {
+
+    @Test
+    public void testSomeZones() {
+        ArrayList<ZoneId> timeZones = new ArrayList<> ();
+        timeZones.add (ZoneId.of("Europe/Berlin"));
+         TimeZoneEngine engine = TimeZoneEngine.initialize (timeZones, true);
+        assertEquals(Optional.of(ZoneId.of("Europe/Berlin")), engine.query(52.52, 13.40));
+        
+        timeZones.clear ();
+        timeZones.add(ZoneId.of("America/Detroit"));
+        engine = TimeZoneEngine.initialize (timeZones, true);
+        assertEquals(Optional.empty (), engine.query(52.52, 13.40));
+
+        timeZones.add(ZoneId.of("Europe/Berlin"));
+        engine = TimeZoneEngine.initialize (timeZones, true);
+        assertEquals(Optional.of(ZoneId.of("Europe/Berlin")), engine.query(52.52, 13.40));
+    }
+}

--- a/core/src/test/java/net/iakovlev/timeshape/TimeZoneEngineSerializationTest.java
+++ b/core/src/test/java/net/iakovlev/timeshape/TimeZoneEngineSerializationTest.java
@@ -11,19 +11,13 @@ import java.io.FileOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
-import java.time.ZoneId;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 import java.io.File;
 
 import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertTrue;
 
 @RunWith(JUnit4.class)
 public class TimeZoneEngineSerializationTest {
-    private static TimeZoneEngine engine = TimeZoneEngine.initialize(47.0599, 4.8237, 55.3300, 15.2486, true);
+    private final static TimeZoneEngine engine = TimeZoneEngine.initialize(47.0599, 4.8237, 55.3300, 15.2486, true);
 
     @Test
     public void testSerialzation() {
@@ -48,6 +42,7 @@ public class TimeZoneEngineSerializationTest {
      *
      * @param f Destination File. 
      * @param eng Instance of TimeZoneEngine to serialize
+    * @throws java.io.IOException
      */
 
     public void serializeTimeZoneEngine (File f, TimeZoneEngine eng) throws IOException
@@ -64,7 +59,10 @@ public class TimeZoneEngineSerializationTest {
      * Creates a new instance of {@link TimeZoneEngine} from previously serialized data.
      * This is a blocking long running operation.
      *
+    * @param f File to de-serialize from
      * @return an initialized instance of {@link TimeZoneEngine}
+    * @throws java.io.IOException
+    * @throws java.lang.ClassNotFoundException
      */
     public static TimeZoneEngine deserializeTimeZoneEngine (File f) throws IOException, ClassNotFoundException
     {


### PR DESCRIPTION
commit cdab7ade8433e9ef8661b935fbde0ec8125c7354
Merge: d025c9f ddcaf60
Author: kevin <kevin@blackholeofphotography.com>
Date:   Sun Jan 4 19:59:49 2026 -0500

    Merge branch 'InitializeByZoneNames' of https://github.com/PhotoKevin/timeshape into InitializeByZoneNames

commit d025c9fdc79875bb3213c38c9f41cf8ece081bde
Author: kevin <kevin@blackholeofphotography.com>
Date:   Sun Jan 4 19:59:43 2026 -0500

    Added an example of the new initializer method.

commit ddcaf60d30e750654625a0cc881c0a25e6126b4b
Merge: c54ff64 ff837e7
Author: Kevin <kevin@blackholeofphotography.com>
Date:   Sun Jan 4 19:48:28 2026 -0500

    Merge branch 'RomanIakovlev:master' into InitializeByZoneNames

commit c54ff644a365e8fbf21e8272346a33a66a9370e2
Author: kevin <kevin@blackholeofphotography.com>
Date:   Sat Jan 3 13:34:06 2026 -0500

    Parameter order on assertEquals was backwards

    assertEquals parameters were reversed. Changed to expected, actual.

commit 180966dab51259cec61173fa79067696e80dc211
Author: kevin <kevin@blackholeofphotography.com>
Date:   Sat Jan 3 13:31:18 2026 -0500

    New initialization functions that use a list of ZoneIds.

    Added initialization functions to use a lists of ZoneIds. Users may find it easier to determine which time zones they're interested in instead what the bounding box is for, say, all of Europe.

    Added documentation comments for parameters.