### PR TITLE
Replace the Esri geometry backend with a purpose-built spatial index

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -94,17 +94,47 @@ Data can also be read from an external file, see overloads of `TimeZoneEngine.in
 (see [here](doc/Architecture.md#builder)).
 It is responsibility of caller to close input stream passed to `TimeZoneEngine.initialize`.
 
+##### Trading memory for query speed
+
 There is an overload of `TimeZoneEngine.initialize` method that accepts a boolean parameter called
-`accelerateGeometry`. If that parameter is equals to `true`, Timeshape will build a bitmap index
-for each polygon it loads. This requires some extra memory and takes time at initialization, hence
-that parameter is being `false` by default, however it speeds up the typical point-in-polygon query
-approximately 2.5 times. See performance benchmarks in `AcceleratedGeometryBenchmark.java`, and
-here is the result:
+`accelerateGeometry`. If that parameter is equal to `true`, Timeshape indexes the edges of every
+polygon it loads by the latitude band they span. A query then only visits the edges that can
+possibly cross the queried latitude, instead of all of them, which for the larger time zones means
+a handful of edges rather than the hundred thousand or so they are made of.
+
+It is a straight trade of memory for query speed, and it is a steep one in both directions:
+
+|                                         | `false` (default) | `true`   |
+|-----------------------------------------|-------------------|----------|
+| Memory, whole world                     | ~64 MB            | ~116 MB  |
+| Memory, bounding box covering 39 zones  | ~1.4 MB           | ~2.6 MB  |
+| Initialization, whole world             | ~1.3 s            | ~1.4 s   |
+| One lookup, random world coordinate     | ~106 µs           | ~0.55 µs |
+
+**Turn it on** if your program does more than a handful of lookups. Two orders of magnitude per
+query is hard to make up elsewhere, and initialization barely notices.
+
+**Leave it off** if memory is your scarce resource — on Android, or when many engines are held at
+once. The index is not a small fixed cost: it grows with the number of polygon edges, and adds
+roughly 80% to the footprint of a world-wide engine.
+
+If you are unsure, note that both settings are a large improvement over the releases that preceded
+the rewrite of the geometry backend, which needed roughly 176 MB and about 1 ms per lookup no matter
+how this parameter was set. Upgrading without changing anything already reduces memory use.
+
+The parameter only defaults to `false` on `initialize()` and on the `initialize(TarArchiveInputStream)`
+overload; every other overload takes it explicitly.
+
+See the benchmarks in `AcceleratedGeometryBenchmark.java`, which query 20 major cities per operation:
 ```
-[info] Benchmark                                               Mode  Cnt   Score   Error  Units
-[info] AcceleratedGeometryBenchmark.testAcceleratedEngine     thrpt   10  38.142 ± 0.448  ops/s
-[info] AcceleratedGeometryBenchmark.testNonAcceleratedEngine  thrpt   10  15.289 ± 0.121  ops/s
+Benchmark                                               Mode  Cnt       Score        Error  Units
+AcceleratedGeometryBenchmark.testAcceleratedEngine     thrpt    5  252055.083 ± 30446.750  ops/s
+AcceleratedGeometryBenchmark.testNonAcceleratedEngine  thrpt    5     137.417 ±   12.103  ops/s
 ```
+Those coordinates all sit deep inside dense land polygons, which is the best case for the index; the
+per-lookup figures in the table above come from uniformly random world coordinates, which is closer
+to a worst case. Expect something between the two, and treat all absolute numbers as indicative —
+they were measured single-threaded on JDK 21 and will differ on your hardware.
 
 
 ##### Improving start up time by using serialization
@@ -154,9 +184,9 @@ show significant speedup of using this method for querying a polyline, comparing
 using `Optional<ZoneId> query(double latitude, double longitude)` method:
 
 ```
-Benchmark                                  Mode  Cnt  Score   Error  Units
-PolylineQueryBenchmark.testQueryPoints    thrpt    5  2,188 ▒ 0,044  ops/s
-PolylineQueryBenchmark.testQueryPolyline  thrpt    5  4,073 ▒ 0,017  ops/s
+Benchmark                                  Mode  Cnt   Score   Error  Units
+PolylineQueryBenchmark.testQueryPoints    thrpt    5  15.554 ± 1.123  ops/s
+PolylineQueryBenchmark.testQueryPolyline  thrpt    5  52.402 ± 3.565  ops/s
 ```
 
 ### Architecture

--- a/benchmarks/src/main/java/net/iakovlev/timeshape/BasicGeoOperationsBenchmark.java
+++ b/benchmarks/src/main/java/net/iakovlev/timeshape/BasicGeoOperationsBenchmark.java
@@ -1,7 +1,5 @@
 package net.iakovlev.timeshape;
 
-import com.esri.core.geometry.*;
-import net.iakovlev.timeshape.TimeZoneEngine;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
@@ -11,71 +9,93 @@ import org.openjdk.jmh.infra.Blackhole;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 
+/**
+ * Measures the two steps a coordinate lookup is made of, in isolation: narrowing the world down to
+ * a handful of candidate polygons, and testing a coordinate against one polygon.
+ * <p>
+ * The engine is initialized without geometry acceleration, so the containment benchmarks walk every
+ * edge of the polygon. {@link AcceleratedGeometryBenchmark} covers the indexed variant.
+ */
 public class BasicGeoOperationsBenchmark {
     @State(Scope.Benchmark)
     public static class BenchmarkState {
         TimeZoneEngine engine = TimeZoneEngine.initialize();
         Index index;
-        QuadTree quadTree;
-        Point p = new Point(13.31, 52.52);
+        Index.Grid grid;
+
+        /** Berlin, well inside a single large polygon. */
+        double lon = 13.31;
+        double lat = 52.52;
+        /**
+         * Jerusalem, where several time zones overlap. Needed because around Berlin every polygon
+         * whose bounding box covers the point also contains it, which would leave the non-matching
+         * benchmark below with an empty list and nothing to measure.
+         */
+        double crowdedLon = 35.2;
+        double crowdedLat = 31.95;
+
         ArrayList<Index.Entry> entries;
-        Geometry matchingGeometry;
-        ArrayList<Geometry> nonMatchingGeometries = new ArrayList<>();
-        SpatialReference spatialReference = SpatialReference.create(4326);
+        PreparedPolygon matchingGeometry;
+        ArrayList<PreparedPolygon> nonMatchingGeometries = new ArrayList<>();
+
         @Setup
         public void setup() {
             try {
                 Field indexField = engine.getClass().getDeclaredField("index");
                 indexField.setAccessible(true);
                 index = (Index) indexField.get(engine);
-                Field quadTreeField = index.getClass().getDeclaredField("quadTree");
-                quadTreeField.setAccessible(true);
-                quadTree = (QuadTree) quadTreeField.get(index);
+                Field gridField = index.getClass().getDeclaredField("grid");
+                gridField.setAccessible(true);
+                grid = (Index.Grid) gridField.get(index);
                 Field zoneIdsField = index.getClass().getDeclaredField("zoneIds");
                 zoneIdsField.setAccessible(true);
-                entries = (ArrayList<Index.Entry>) zoneIdsField.get(index);
-                QuadTree.QuadTreeIterator iterator = quadTree.getIterator(p, 0);
-                for (int i = iterator.next(); i >= 0; i = iterator.next()) {
-                    int element = quadTree.getElement(i);
-                    Index.Entry entry = entries.get(element);
-                    if (GeometryEngine.contains(entry.geometry, p, spatialReference)) {
-                        matchingGeometry = entry.geometry;
-                    } else {
-                        nonMatchingGeometries.add(entry.geometry);
-                    }
-
-                }
+                @SuppressWarnings("unchecked")
+                ArrayList<Index.Entry> zoneIds = (ArrayList<Index.Entry>) zoneIdsField.get(index);
+                entries = zoneIds;
             } catch (NoSuchFieldException | IllegalAccessException e) {
-                e.printStackTrace();
                 throw new RuntimeException(e);
             }
-        }
 
+            for (Index.Entry entry : entries) {
+                PreparedPolygon geometry = entry.geometry;
+                if (geometry.contains(lon, lat)) {
+                    matchingGeometry = geometry;
+                }
+                boolean crowdedIsInBoundingBox = crowdedLon >= geometry.minX && crowdedLon <= geometry.maxX
+                        && crowdedLat >= geometry.minY && crowdedLat <= geometry.maxY;
+                if (crowdedIsInBoundingBox && !geometry.contains(crowdedLon, crowdedLat)) {
+                    nonMatchingGeometries.add(geometry);
+                }
+            }
+            if (matchingGeometry == null || nonMatchingGeometries.isEmpty()) {
+                throw new IllegalStateException("Benchmark points no longer exercise what they are meant to");
+            }
+        }
     }
 
-
+    /** Narrowing a coordinate down to the polygons that may contain it. */
     @Benchmark
     public void testQuadTree(BenchmarkState state, Blackhole blackhole) {
-        QuadTree.QuadTreeIterator iterator = state.quadTree.getIterator(state.p, 0);
-        for (int i = iterator.next(); i >= 0; i = iterator.next()) {
-            blackhole.consume(state.quadTree.getElement(i));
+        int cell = state.grid.cellOf(state.lon, state.lat);
+        for (int i = state.grid.firstPolygonOf(cell), end = state.grid.lastPolygonOf(cell); i < end; i++) {
+            blackhole.consume(state.grid.polygonAt(i));
         }
     }
 
     @Benchmark
     public void testSearchInNonMatchingGeometry(BenchmarkState state, Blackhole blackhole) {
-        for (Geometry g : state.nonMatchingGeometries) {
-            blackhole.consume(GeometryEngine.contains(g, state.p, state.spatialReference));
+        for (PreparedPolygon g : state.nonMatchingGeometries) {
+            blackhole.consume(g.contains(state.crowdedLon, state.crowdedLat));
         }
     }
 
     @Benchmark
     public void testSearchInMatchingGeometry(BenchmarkState state, Blackhole blackhole) {
-        blackhole.consume(GeometryEngine.contains(state.matchingGeometry, state.p, state.spatialReference));
+        blackhole.consume(state.matchingGeometry.contains(state.lon, state.lat));
     }
 
     @Benchmark
     public void testIndexQuery(BenchmarkState state, Blackhole blackhole) {
-        blackhole.consume(state.index.query(state.p.getY(), state.p.getX()));
+        blackhole.consume(state.index.query(state.lat, state.lon));
     }
 }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -34,10 +34,6 @@
             <groupId>com.github.luben</groupId>
             <artifactId>zstd-jni</artifactId>
         </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-        </dependency>
 
         <!-- Test dependencies -->
         <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -18,11 +18,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.esri.geometry</groupId>
-            <artifactId>esri-geometry-api</artifactId>
-            <version>2.2.4</version>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>1.7.30</version>

--- a/core/src/main/java/net/iakovlev/timeshape/Index.java
+++ b/core/src/main/java/net/iakovlev/timeshape/Index.java
@@ -1,6 +1,5 @@
 package net.iakovlev.timeshape;
 
-import com.esri.core.geometry.*;
 import net.iakovlev.timeshape.proto.Geojson;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -10,33 +9,163 @@ import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
-import java.util.PrimitiveIterator;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 final class Index implements Serializable {
-    static final class Entry implements Serializable {
-        final ZoneId zoneId;
-        final Geometry geometry;
 
-        Entry(ZoneId zoneId, Geometry geometry) {
+    private static final long serialVersionUID = 1L;
+
+    static final class Entry implements Serializable {
+        private static final long serialVersionUID = 1L;
+
+        final ZoneId zoneId;
+        final PreparedPolygon geometry;
+
+        Entry(ZoneId zoneId, PreparedPolygon geometry) {
             this.zoneId = zoneId;
             this.geometry = geometry;
         }
     }
 
-    private static final int WGS84_WKID = 4326;
+    /**
+     * A uniform grid over the indexed area, mapping each cell to the polygons whose bounding box
+     * overlaps it. Looking up the candidates for a point is a bit of arithmetic and one array
+     * offset, with no tree to descend and nothing to allocate.
+     */
+    static final class Grid implements Serializable {
+        private static final long serialVersionUID = 1L;
+
+        /** Roughly one degree per cell, which keeps the world grid at 360x180 cells. */
+        private static final double TARGET_CELL_SIZE_DEGREES = 1.0;
+        private static final int MAX_CELLS_PER_AXIS = 1024;
+
+        private final double minX;
+        private final double minY;
+        private final double maxX;
+        private final double maxY;
+        private final int cellsX;
+        private final int cellsY;
+        private final double cellsPerDegreeX;
+        private final double cellsPerDegreeY;
+        /** Cell {@code c} owns {@code [cellStart[c], cellStart[c + 1])} of {@link #cellPolygons}. */
+        private final int[] cellStart;
+        /** Polygon indices, ascending within every cell. */
+        private final int[] cellPolygons;
+
+        private Grid(double minX, double minY, double maxX, double maxY,
+                     int cellsX, int cellsY, int[] cellStart, int[] cellPolygons) {
+            this.minX = minX;
+            this.minY = minY;
+            this.maxX = maxX;
+            this.maxY = maxY;
+            this.cellsX = cellsX;
+            this.cellsY = cellsY;
+            this.cellsPerDegreeX = cellsX / (maxX - minX);
+            this.cellsPerDegreeY = cellsY / (maxY - minY);
+            this.cellStart = cellStart;
+            this.cellPolygons = cellPolygons;
+        }
+
+        static Grid build(List<Entry> entries) {
+            double minX = Double.POSITIVE_INFINITY, minY = Double.POSITIVE_INFINITY;
+            double maxX = Double.NEGATIVE_INFINITY, maxY = Double.NEGATIVE_INFINITY;
+            for (int i = 0; i < entries.size(); i++) {
+                PreparedPolygon p = entries.get(i).geometry;
+                if (p.minX < minX) minX = p.minX;
+                if (p.maxX > maxX) maxX = p.maxX;
+                if (p.minY < minY) minY = p.minY;
+                if (p.maxY > maxY) maxY = p.maxY;
+            }
+            if (entries.isEmpty()) {
+                return new Grid(0, 0, 1, 1, 1, 1, new int[]{0, 0}, new int[0]);
+            }
+            // Keep the extent non-degenerate so that the cell size stays a finite number.
+            if (maxX <= minX) {
+                maxX = minX + 1.0E-6;
+            }
+            if (maxY <= minY) {
+                maxY = minY + 1.0E-6;
+            }
+
+            int cellsX = cellCount(maxX - minX);
+            int cellsY = cellCount(maxY - minY);
+            double perDegreeX = cellsX / (maxX - minX);
+            double perDegreeY = cellsY / (maxY - minY);
+            int cellCount = cellsX * cellsY;
+
+            // Two passes: count how many polygons land in every cell, then fill the flat array.
+            int[] cellStart = new int[cellCount + 1];
+            for (int i = 0; i < entries.size(); i++) {
+                PreparedPolygon p = entries.get(i).geometry;
+                int fromX = clamp((p.minX - minX) * perDegreeX, cellsX), toX = clamp((p.maxX - minX) * perDegreeX, cellsX);
+                int fromY = clamp((p.minY - minY) * perDegreeY, cellsY), toY = clamp((p.maxY - minY) * perDegreeY, cellsY);
+                for (int cy = fromY; cy <= toY; cy++) {
+                    for (int cx = fromX; cx <= toX; cx++) {
+                        cellStart[cy * cellsX + cx + 1]++;
+                    }
+                }
+            }
+            for (int c = 0; c < cellCount; c++) {
+                cellStart[c + 1] += cellStart[c];
+            }
+
+            int[] cursor = new int[cellCount];
+            System.arraycopy(cellStart, 0, cursor, 0, cellCount);
+            int[] cellPolygons = new int[cellStart[cellCount]];
+            for (int i = 0; i < entries.size(); i++) {
+                PreparedPolygon p = entries.get(i).geometry;
+                int fromX = clamp((p.minX - minX) * perDegreeX, cellsX), toX = clamp((p.maxX - minX) * perDegreeX, cellsX);
+                int fromY = clamp((p.minY - minY) * perDegreeY, cellsY), toY = clamp((p.maxY - minY) * perDegreeY, cellsY);
+                for (int cy = fromY; cy <= toY; cy++) {
+                    for (int cx = fromX; cx <= toX; cx++) {
+                        cellPolygons[cursor[cy * cellsX + cx]++] = i;
+                    }
+                }
+            }
+            return new Grid(minX, minY, maxX, maxY, cellsX, cellsY, cellStart, cellPolygons);
+        }
+
+        private static int clamp(double cell, int cellCount) {
+            int c = (int) cell;
+            if (c < 0) return 0;
+            return c >= cellCount ? cellCount - 1 : c;
+        }
+
+        private static int cellCount(double extentDegrees) {
+            int count = (int) Math.ceil(extentDegrees / TARGET_CELL_SIZE_DEGREES);
+            return Math.max(1, Math.min(MAX_CELLS_PER_AXIS, count));
+        }
+
+        /** Index of the cell containing the point, or -1 if the point is outside the indexed area. */
+        int cellOf(double x, double y) {
+            if (x < minX || x > maxX || y < minY || y > maxY) {
+                return -1;
+            }
+            return clamp((y - minY) * cellsPerDegreeY, cellsY) * cellsX + clamp((x - minX) * cellsPerDegreeX, cellsX);
+        }
+
+        int firstPolygonOf(int cell) {
+            return cellStart[cell];
+        }
+
+        int lastPolygonOf(int cell) {
+            return cellStart[cell + 1];
+        }
+
+        int polygonAt(int position) {
+            return cellPolygons[position];
+        }
+    }
+
     private final ArrayList<Entry> zoneIds;
-    private static final SpatialReference spatialReference = SpatialReference.create(WGS84_WKID);
-    private final QuadTree quadTree;
+    private final Grid grid;
     private static final Logger log = LoggerFactory.getLogger(Index.class);
 
-    private Index(QuadTree quadTree, ArrayList<Entry> zoneIds) {
+    private Index(Grid grid, ArrayList<Entry> zoneIds) {
         log.info("Initialized index with {} time zones", zoneIds.size());
-        this.quadTree = quadTree;
+        this.grid = grid;
         this.zoneIds = zoneIds;
     }
 
@@ -45,43 +174,70 @@ final class Index implements Serializable {
     }
 
     List<ZoneId> query(double latitude, double longitude) {
-        ArrayList<ZoneId> result = new ArrayList<>(2);
-        Point point = new Point(longitude, latitude);
-        OperatorIntersects operator = OperatorIntersects.local();
-        QuadTree.QuadTreeIterator iterator = quadTree.getIterator(point, 0);
-        for (int i = iterator.next(); i >= 0; i = iterator.next()) {
-            int element = quadTree.getElement(i);
-            Entry entry = zoneIds.get(element);
-            if(operator.execute(entry.geometry, point, spatialReference, null)) {
-                result.add(entry.zoneId);
+        int cell = grid.cellOf(longitude, latitude);
+        if (cell < 0) {
+            return Collections.emptyList();
+        }
+        ZoneId first = null;
+        ArrayList<ZoneId> result = null;
+        for (int i = grid.firstPolygonOf(cell), end = grid.lastPolygonOf(cell); i < end; i++) {
+            Entry entry = zoneIds.get(grid.polygonAt(i));
+            if (entry.geometry.contains(longitude, latitude)) {
+                if (first == null) {
+                    first = entry.zoneId;
+                } else {
+                    if (result == null) {
+                        result = new ArrayList<>(2);
+                        result.add(first);
+                    }
+                    result.add(entry.zoneId);
+                }
             }
         }
-        return result;
+        if (result != null) {
+            return result;
+        }
+        return first == null ? Collections.emptyList() : Collections.singletonList(first);
+    }
+
+    /**
+     * Collects the entries covering a point. Returns an empty list rather than null when nothing
+     * matches, so callers can treat the result uniformly.
+     */
+    private List<Entry> entriesAt(double longitude, double latitude) {
+        int cell = grid.cellOf(longitude, latitude);
+        if (cell < 0) {
+            return Collections.emptyList();
+        }
+        List<Entry> matching = null;
+        for (int i = grid.firstPolygonOf(cell), end = grid.lastPolygonOf(cell); i < end; i++) {
+            Entry entry = zoneIds.get(grid.polygonAt(i));
+            if (entry.geometry.contains(longitude, latitude)) {
+                if (matching == null) {
+                    matching = new ArrayList<>(2);
+                }
+                matching.add(entry);
+            }
+        }
+        return matching == null ? Collections.<Entry>emptyList() : matching;
+    }
+
+    private static boolean allContain(List<Entry> entries, double longitude, double latitude) {
+        for (int i = 0; i < entries.size(); i++) {
+            if (!entries.get(i).geometry.contains(longitude, latitude)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     List<SameZoneSpan> queryPolyline(double[] line) {
-
-        Polyline polyline = new Polyline();
-        ArrayList<Point> points = new ArrayList<>(line.length / 2);
-        for (int i = 0; i < line.length - 1; i += 2) {
-            Point p = new Point(line[i + 1], line[i]);
-            points.add(p);
-        }
-        polyline.startPath(points.get(0));
-        for (int i = 1; i < points.size(); i += 1) {
-            polyline.lineTo(points.get(i));
-        }
-        QuadTree.QuadTreeIterator iterator = quadTree.getIterator(polyline, 0);
-
-        ArrayList<Entry> potentiallyMatchingEntries = new ArrayList<>();
-
-        for (int i = iterator.next(); i >= 0; i = iterator.next()) {
-            int element = quadTree.getElement(i);
-            Entry entry = zoneIds.get(element);
-            potentiallyMatchingEntries.add(entry);
-        }
-
         ArrayList<SameZoneSpan> sameZoneSegments = new ArrayList<>();
+        int pointCount = line.length / 2;
+        if (pointCount == 0) {
+            return sameZoneSegments;
+        }
+
         List<Entry> currentEntry = null;
         // 1. find next matching geometry or geometries
         // 2. for every match, increase the index
@@ -89,14 +245,15 @@ final class Index implements Serializable {
         // 4. goto 1.
         int index = 0;
         boolean lastWasEmpty = false;
-        OperatorIntersects operator = OperatorIntersects.local();
-        while (index < points.size()) {
-            Point p = points.get(index);
+        // The entries were just looked up by containment at this very point, so re-testing them
+        // would be pure repetition.
+        boolean freshlyMatched = false;
+        while (index < pointCount) {
+            double latitude = line[index * 2];
+            double longitude = line[index * 2 + 1];
             if (currentEntry == null) {
-                currentEntry = potentiallyMatchingEntries
-                        .stream()
-                        .filter(e -> operator.execute(e.geometry, p, spatialReference, null))
-                        .collect(Collectors.toList());
+                currentEntry = entriesAt(longitude, latitude);
+                freshlyMatched = true;
             }
             if (currentEntry.isEmpty()) {
                 currentEntry = null;
@@ -105,11 +262,12 @@ final class Index implements Serializable {
             } else {
                 if (lastWasEmpty) {
                     lastWasEmpty = false;
-                    sameZoneSegments.add(SameZoneSpan.fromIndexEntries(Collections.emptyList(), (index - 1) * 2 + 1));
+                    sameZoneSegments.add(SameZoneSpan.fromIndexEntries(Collections.<Entry>emptyList(), (index - 1) * 2 + 1));
                     continue;
                 }
-                if (currentEntry.stream().allMatch(e -> operator.execute(e.geometry, p, spatialReference, null))) {
-                    if (index == points.size() - 1) {
+                if (freshlyMatched || allContain(currentEntry, longitude, latitude)) {
+                    freshlyMatched = false;
+                    if (index == pointCount - 1) {
                         sameZoneSegments.add(SameZoneSpan.fromIndexEntries(currentEntry, index * 2 + 1));
                     }
                     index++;
@@ -121,121 +279,92 @@ final class Index implements Serializable {
         }
 
         if (lastWasEmpty) {
-            sameZoneSegments.add(SameZoneSpan.fromIndexEntries(Collections.emptyList(), index * 2 - 1));
+            sameZoneSegments.add(SameZoneSpan.fromIndexEntries(Collections.<Entry>emptyList(), index * 2 - 1));
         }
 
         return sameZoneSegments;
     }
 
-    private static Polygon buildPoly(Geojson.Polygon from) {
-        Polygon poly = new Polygon();
-        from.getCoordinatesList().stream()
-                .map(Geojson.LineString::getCoordinatesList)
-                .forEachOrdered(lp -> {
-                    poly.startPath(lp.get(0).getLon(), lp.get(0).getLat());
-                    lp.subList(1, lp.size()).forEach(p -> poly.lineTo(p.getLon(), p.getLat()));
-                });
-        return poly;
-    }
-
-    static Index build(Stream<Geojson.Feature> features, int size, Envelope boundaries) {
-        return build(features, size, boundaries, false);
-    }
-
-    private static Stream<Polygon> getPolygons(Geojson.Feature f) {
+    private static Stream<Geojson.Polygon> getPolygons(Geojson.Feature f) {
         if (f.getGeometry().hasPolygon()) {
-            return Stream.of(buildPoly(f.getGeometry().getPolygon()));
+            return Stream.of(f.getGeometry().getPolygon());
         } else if (f.getGeometry().hasMultiPolygon()) {
-            Geojson.MultiPolygon multiPolygonProto = f.getGeometry().getMultiPolygon();
-            return multiPolygonProto.getCoordinatesList().stream().map(Index::buildPoly);
+            return f.getGeometry().getMultiPolygon().getCoordinatesList().stream();
         } else {
             throw new RuntimeException("Unknown geometry type");
         }
     }
 
-    @SuppressWarnings("SizeReplaceableByIsEmpty")
-    static Index build(Stream<Geojson.Feature> features, int size, Envelope boundaries, boolean accelerateGeometry) {
-        Envelope2D boundariesEnvelope = new Envelope2D();
-        boundaries.queryEnvelope2D(boundariesEnvelope);
-        QuadTree quadTree = new QuadTree(boundariesEnvelope, 8);
-        Envelope2D env = new Envelope2D();
-        ArrayList<Entry> zoneIds = new ArrayList<>(size);
-        PrimitiveIterator.OfInt indices = IntStream.iterate(0, i -> i + 1).iterator();
-        List<String> unknownZones = new ArrayList<>();
-        OperatorIntersects operatorIntersects = OperatorIntersects.local();
-        features.forEach(f -> {
-            String zoneIdName = f.getProperties(0).getValueString();
-            try {
-                ZoneId zoneId = ZoneId.of(zoneIdName);
-                getPolygons(f).forEach(polygon -> {
-                    if (GeometryEngine.contains(boundaries, polygon, spatialReference)) {
-                        log.debug("Adding zone {} to index", zoneIdName);
-                        if (accelerateGeometry) {
-                            operatorIntersects.accelerateGeometry(polygon, spatialReference, Geometry.GeometryAccelerationDegree.enumMild);
-                        }
-                        polygon.queryEnvelope2D(env);
-                        int index = indices.next();
-                        quadTree.insert(index, env);
-                        zoneIds.add(index, new Entry(zoneId, polygon));
-                    } else {
-                        log.debug("Not adding zone {} to index because it's out of provided boundaries", zoneIdName);
-                    }
-                });
-            } catch (Exception ex) {
-                unknownZones.add(zoneIdName);
-            }
-        });
-        if (unknownZones.size() != 0) {
-            String allUnknownZones = String.join(", ", unknownZones);
-            log.error(
-                    "Some of the zone ids were not recognized by the Java runtime and will be ignored. " +
-                            "The most probable reason for this is outdated Java runtime version. " +
-                            "The following zones were not recognized: " + allUnknownZones);
-        }
-        return new Index(quadTree, zoneIds);
+    static Index build(Stream<Geojson.Feature> features, int size,
+                       double minLat, double minLon, double maxLat, double maxLon) {
+        return build(features, size, minLat, minLon, maxLat, maxLon, false);
     }
 
-    
-    @SuppressWarnings("SizeReplaceableByIsEmpty")
-    static Index build(Stream<Geojson.Feature> features, int size, Set<ZoneId> timeZones, boolean accelerateGeometry) {
-        Envelope2D boundariesEnvelope = new Envelope2D();
-        Envelope boundaries = new Envelope(-180, -90, 180, +90);// (minLon, minLat, maxLon, maxLat);
-        boundaries.queryEnvelope2D(boundariesEnvelope);
-        QuadTree quadTree = new QuadTree(boundariesEnvelope, 8);
-        Envelope2D env = new Envelope2D();
+    static Index build(Stream<Geojson.Feature> features, int size,
+                       double minLat, double minLon, double maxLat, double maxLon,
+                       boolean accelerateGeometry) {
         ArrayList<Entry> zoneIds = new ArrayList<>(size);
-        PrimitiveIterator.OfInt indices = IntStream.iterate(0, i -> i + 1).iterator();
         List<String> unknownZones = new ArrayList<>();
-        OperatorIntersects operatorIntersects = OperatorIntersects.local();
         features.forEach(f -> {
             String zoneIdName = f.getProperties(0).getValueString();
+            ZoneId zoneId;
             try {
-                ZoneId zoneId = ZoneId.of(zoneIdName);
-                if (timeZones.contains (zoneId)) {
-                    getPolygons(f).forEach(polygon -> {
-                        log.debug("Adding zone {} to index", zoneIdName);
-                        if (accelerateGeometry) {
-                            operatorIntersects.accelerateGeometry(polygon, spatialReference, Geometry.GeometryAccelerationDegree.enumMild);
-                        }
-                        polygon.queryEnvelope2D(env);
-                        int index = indices.next();
-                        quadTree.insert(index, env);
-                        zoneIds.add(index, new Entry(zoneId, polygon));
-                    });
+                zoneId = ZoneId.of(zoneIdName);
+            } catch (Exception ex) {
+                unknownZones.add(zoneIdName);
+                return;
+            }
+            getPolygons(f).forEach(protoPolygon -> {
+                PreparedPolygon polygon = PreparedPolygon.fromProto(protoPolygon, accelerateGeometry);
+                // A zone is only indexed when it fits into the requested boundaries entirely, which
+                // for an axis aligned box is exactly the same as its bounding box fitting.
+                if (polygon != null && polygon.isWithin(minLon, minLat, maxLon, maxLat)) {
+                    log.debug("Adding zone {} to index", zoneIdName);
+                    zoneIds.add(new Entry(zoneId, polygon));
                 } else {
                     log.debug("Not adding zone {} to index because it's out of provided boundaries", zoneIdName);
                 }
+            });
+        });
+        reportUnknownZones(unknownZones);
+        return new Index(Grid.build(zoneIds), zoneIds);
+    }
+
+    static Index build(Stream<Geojson.Feature> features, int size, Set<ZoneId> timeZones, boolean accelerateGeometry) {
+        ArrayList<Entry> zoneIds = new ArrayList<>(size);
+        List<String> unknownZones = new ArrayList<>();
+        features.forEach(f -> {
+            String zoneIdName = f.getProperties(0).getValueString();
+            ZoneId zoneId;
+            try {
+                zoneId = ZoneId.of(zoneIdName);
             } catch (Exception ex) {
                 unknownZones.add(zoneIdName);
+                return;
             }
+            if (!timeZones.contains(zoneId)) {
+                log.debug("Not adding zone {} to index because it's not in the requested set", zoneIdName);
+                return;
+            }
+            getPolygons(f).forEach(protoPolygon -> {
+                PreparedPolygon polygon = PreparedPolygon.fromProto(protoPolygon, accelerateGeometry);
+                if (polygon != null) {
+                    log.debug("Adding zone {} to index", zoneIdName);
+                    zoneIds.add(new Entry(zoneId, polygon));
+                }
+            });
         });
-        if (unknownZones.size() != 0) {
+        reportUnknownZones(unknownZones);
+        return new Index(Grid.build(zoneIds), zoneIds);
+    }
+
+    private static void reportUnknownZones(List<String> unknownZones) {
+        if (!unknownZones.isEmpty()) {
             String allUnknownZones = String.join(", ", unknownZones);
             log.error(
                     "Some of the zone ids were not recognized by the Java runtime and will be ignored. " +
                             "The most probable reason for this is outdated Java runtime version. " +
                             "The following zones were not recognized: " + allUnknownZones);
         }
-        return new Index(quadTree, zoneIds);
     }
 }

--- a/core/src/main/java/net/iakovlev/timeshape/PreparedPolygon.java
+++ b/core/src/main/java/net/iakovlev/timeshape/PreparedPolygon.java
@@ -1,0 +1,331 @@
+package net.iakovlev.timeshape;
+
+import net.iakovlev.timeshape.proto.Geojson;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * A polygon stored in a layout that makes point-in-polygon queries cheap.
+ * <p>
+ * All rings of the polygon are concatenated into two flat coordinate arrays, so a query walks
+ * contiguous memory instead of chasing objects. Coordinates are kept as {@code float}, which is
+ * lossless: the source data is float precision to begin with. Arithmetic is done in {@code double},
+ * so widening the inputs introduces no rounding of its own.
+ * <p>
+ * Optionally the polygon carries a latitude index: edges are bucketed by the latitude band they
+ * span, so a query only visits the edges that can possibly cross the query latitude instead of all
+ * of them. For the larger time zones this turns an O(vertices) scan into a handful of edge tests.
+ */
+final class PreparedPolygon implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Points closer than this to the outline count as being inside the polygon. Time zones share
+     * their borders, so a coordinate that sits exactly on one belongs to both of its neighbours.
+     * The value matches the tolerance of the WGS84 spatial reference, which is what the library
+     * used to inherit from the geometry engine it was built on.
+     */
+    private static final double TOLERANCE = 1.0E-8;
+    private static final double TOLERANCE_SQUARED = TOLERANCE * TOLERANCE;
+
+    /** Longitudes of every ring, concatenated. */
+    private final float[] xs;
+    /** Latitudes of every ring, concatenated. */
+    private final float[] ys;
+    /** Ring {@code r} occupies vertices {@code [ringStart[r], ringStart[r + 1])}, first == last. */
+    private final int[] ringStart;
+
+    final float minX;
+    final float minY;
+    final float maxX;
+    final float maxY;
+
+    /** Start offset of each latitude bucket into {@link #bucketEdges}, or null if not indexed. */
+    private final int[] bucketStart;
+    /** Index of the first vertex of each edge, grouped by latitude bucket. */
+    private final int[] bucketEdges;
+    /** Buckets per degree of latitude. */
+    private final double bucketScale;
+    private final int bucketCount;
+
+    private PreparedPolygon(float[] xs, float[] ys, int[] ringStart,
+                            float minX, float minY, float maxX, float maxY,
+                            int[] bucketStart, int[] bucketEdges, double bucketScale, int bucketCount) {
+        this.xs = xs;
+        this.ys = ys;
+        this.ringStart = ringStart;
+        this.minX = minX;
+        this.minY = minY;
+        this.maxX = maxX;
+        this.maxY = maxY;
+        this.bucketStart = bucketStart;
+        this.bucketEdges = bucketEdges;
+        this.bucketScale = bucketScale;
+        this.bucketCount = bucketCount;
+    }
+
+    /**
+     * Builds a polygon from its protobuf representation.
+     *
+     * @param proto              the GeoJSON polygon, first ring is the exterior one, the rest are holes
+     * @param buildLatitudeIndex whether to spend extra memory on the latitude index
+     * @return the prepared polygon, or null if it has no ring enclosing an area
+     */
+    static PreparedPolygon fromProto(Geojson.Polygon proto, boolean buildLatitudeIndex) {
+        List<Geojson.LineString> rings = proto.getCoordinatesList();
+        int capacity = 0;
+        for (int r = 0; r < rings.size(); r++) {
+            capacity += rings.get(r).getCoordinatesCount() + 1;
+        }
+        float[] xs = new float[capacity];
+        float[] ys = new float[capacity];
+        int[] starts = new int[rings.size() + 1];
+
+        int n = 0;
+        int ringCount = 0;
+        for (int r = 0; r < rings.size(); r++) {
+            List<Geojson.Position> positions = rings.get(r).getCoordinatesList();
+            int start = n;
+            for (int i = 0; i < positions.size(); i++) {
+                Geojson.Position p = positions.get(i);
+                float x = p.getLon();
+                float y = p.getLat();
+                // Repeated points contribute nothing but slow every query down.
+                if (n > start && x == xs[n - 1] && y == ys[n - 1]) {
+                    continue;
+                }
+                xs[n] = x;
+                ys[n] = y;
+                n++;
+            }
+            if (n - start < 3) {
+                n = start; // Not enough distinct points to enclose an area.
+                continue;
+            }
+            if (xs[n - 1] != xs[start] || ys[n - 1] != ys[start]) {
+                xs[n] = xs[start];
+                ys[n] = ys[start];
+                n++;
+            }
+            starts[ringCount++] = start;
+        }
+        if (ringCount == 0) {
+            return null;
+        }
+        starts[ringCount] = n;
+
+        xs = Arrays.copyOf(xs, n);
+        ys = Arrays.copyOf(ys, n);
+        int[] ringStart = Arrays.copyOf(starts, ringCount + 1);
+
+        float minX = Float.POSITIVE_INFINITY, minY = Float.POSITIVE_INFINITY;
+        float maxX = Float.NEGATIVE_INFINITY, maxY = Float.NEGATIVE_INFINITY;
+        for (int i = 0; i < n; i++) {
+            float x = xs[i], y = ys[i];
+            if (x < minX) minX = x;
+            if (x > maxX) maxX = x;
+            if (y < minY) minY = y;
+            if (y > maxY) maxY = y;
+        }
+
+        PreparedPolygon polygon =
+                new PreparedPolygon(xs, ys, ringStart, minX, minY, maxX, maxY, null, null, 0, 0);
+        return buildLatitudeIndex ? polygon.withLatitudeIndex() : polygon;
+    }
+
+    /**
+     * Returns a copy of this polygon carrying a latitude index over its edges.
+     * <p>
+     * The bucket height is picked so that the index stays proportional to the polygon size: it is
+     * never finer than the average edge height, which keeps the number of buckets an edge spans
+     * (and therefore the number of times it is listed) close to one.
+     */
+    private PreparedPolygon withLatitudeIndex() {
+        double height = (double) maxY - minY;
+        int edgeCount = 0;
+        double sumEdgeHeight = 0;
+        for (int r = 0; r + 1 < ringStart.length; r++) {
+            for (int v = ringStart[r], last = ringStart[r + 1] - 1; v < last; v++) {
+                edgeCount++;
+                sumEdgeHeight += Math.abs(ys[v + 1] - ys[v]);
+            }
+        }
+        if (edgeCount == 0 || height <= 0) {
+            return this;
+        }
+
+        int maxBuckets = Math.max(1, edgeCount / 2);
+        double bucketHeight = Math.max(height / maxBuckets, 2.0 * sumEdgeHeight / edgeCount);
+        int buckets = (int) Math.min(maxBuckets, Math.max(1, Math.ceil(height / bucketHeight)));
+        double scale = buckets / height;
+
+        // Two passes: count the edges of every bucket, then place them into the flat array.
+        int[] starts = new int[buckets + 1];
+        for (int r = 0; r + 1 < ringStart.length; r++) {
+            for (int v = ringStart[r], last = ringStart[r + 1] - 1; v < last; v++) {
+                int from = bucketOf(Math.min(ys[v], ys[v + 1]), scale, buckets);
+                int to = bucketOf(Math.max(ys[v], ys[v + 1]), scale, buckets);
+                for (int b = from; b <= to; b++) {
+                    starts[b + 1]++;
+                }
+            }
+        }
+        for (int b = 0; b < buckets; b++) {
+            starts[b + 1] += starts[b];
+        }
+
+        int[] cursor = Arrays.copyOf(starts, buckets);
+        int[] edges = new int[starts[buckets]];
+        for (int r = 0; r + 1 < ringStart.length; r++) {
+            for (int v = ringStart[r], last = ringStart[r + 1] - 1; v < last; v++) {
+                int from = bucketOf(Math.min(ys[v], ys[v + 1]), scale, buckets);
+                int to = bucketOf(Math.max(ys[v], ys[v + 1]), scale, buckets);
+                for (int b = from; b <= to; b++) {
+                    edges[cursor[b]++] = v;
+                }
+            }
+        }
+        return new PreparedPolygon(xs, ys, ringStart, minX, minY, maxX, maxY, starts, edges, scale, buckets);
+    }
+
+    private int bucketOf(double y, double scale, int buckets) {
+        int b = (int) ((y - minY) * scale);
+        if (b < 0) {
+            return 0;
+        }
+        return b >= buckets ? buckets - 1 : b;
+    }
+
+    private int bucketOf(double y) {
+        return bucketOf(y, bucketScale, bucketCount);
+    }
+
+    /**
+     * Tests whether the given point belongs to this polygon, that is, whether it is enclosed by the
+     * outer ring, outside of every hole, or within {@link #TOLERANCE} of the outline.
+     *
+     * @param x longitude of the point
+     * @param y latitude of the point
+     */
+    boolean contains(double x, double y) {
+        if (x < minX - TOLERANCE || x > maxX + TOLERANCE || y < minY - TOLERANCE || y > maxY + TOLERANCE) {
+            return false;
+        }
+        if (bucketEdges == null) {
+            return isEnclosedByAllEdges(x, y) || touchesAnyEdge(x, y);
+        }
+        int bucket = bucketOf(y);
+        if (isEnclosedByBucket(x, y, bucket)) {
+            return true;
+        }
+        // Only a point that is not enclosed can still be sitting on the outline, and it can only do
+        // so within a hair of its own latitude, so at most two buckets are worth looking at.
+        return touchesEdgeInBuckets(x, y, bucketOf(y - TOLERANCE), bucketOf(y + TOLERANCE));
+    }
+
+    /**
+     * Counts, using the even-odd rule, how often a ray cast towards increasing longitude crosses
+     * the outline. The half-open comparison {@code (y1 > y) != (y2 > y)} makes a vertex shared by
+     * two edges count exactly once, which is what keeps the rule consistent.
+     */
+    private boolean isEnclosedByBucket(double x, double y, int bucket) {
+        final float[] xs = this.xs;
+        final float[] ys = this.ys;
+        final int[] edges = this.bucketEdges;
+        boolean inside = false;
+        for (int i = bucketStart[bucket], end = bucketStart[bucket + 1]; i < end; i++) {
+            int v = edges[i];
+            double y1 = ys[v], y2 = ys[v + 1];
+            if ((y1 > y) != (y2 > y) && crossesToTheRight(x, y, xs[v], y1, xs[v + 1], y2)) {
+                inside = !inside;
+            }
+        }
+        return inside;
+    }
+
+    /** Same rule as {@link #isEnclosedByBucket}, for polygons built without a latitude index. */
+    private boolean isEnclosedByAllEdges(double x, double y) {
+        final float[] xs = this.xs;
+        final float[] ys = this.ys;
+        boolean inside = false;
+        for (int r = 0; r + 1 < ringStart.length; r++) {
+            for (int v = ringStart[r], last = ringStart[r + 1] - 1; v < last; v++) {
+                double y1 = ys[v], y2 = ys[v + 1];
+                if ((y1 > y) != (y2 > y) && crossesToTheRight(x, y, xs[v], y1, xs[v + 1], y2)) {
+                    inside = !inside;
+                }
+            }
+        }
+        return inside;
+    }
+
+    /** Whether the point lies within {@link #TOLERANCE} of an edge in the given bucket range. */
+    private boolean touchesEdgeInBuckets(double x, double y, int fromBucket, int toBucket) {
+        final float[] xs = this.xs;
+        final float[] ys = this.ys;
+        final int[] edges = this.bucketEdges;
+        for (int i = bucketStart[fromBucket], end = bucketStart[toBucket + 1]; i < end; i++) {
+            int v = edges[i];
+            if (isNearEdge(x, y, xs[v], ys[v], xs[v + 1], ys[v + 1])) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** Same test as {@link #touchesEdgeInBuckets}, for polygons built without a latitude index. */
+    private boolean touchesAnyEdge(double x, double y) {
+        final float[] xs = this.xs;
+        final float[] ys = this.ys;
+        for (int r = 0; r + 1 < ringStart.length; r++) {
+            for (int v = ringStart[r], last = ringStart[r + 1] - 1; v < last; v++) {
+                if (isNearEdge(x, y, xs[v], ys[v], xs[v + 1], ys[v + 1])) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Tells whether the edge from {@code (x1, y1)} to {@code (x2, y2)}, already known to span the
+     * latitude {@code y}, crosses it to the right of {@code x}. Equivalent to comparing {@code x}
+     * with the edge's longitude at latitude {@code y}, but expressed as a cross product to keep the
+     * division out of the inner loop.
+     */
+    private static boolean crossesToTheRight(double x, double y, double x1, double y1, double x2, double y2) {
+        double dx = x2 - x1;
+        double dy = y2 - y1;
+        double side = (x - x1) * dy - (y - y1) * dx;
+        return dy > 0 ? side < 0 : side > 0;
+    }
+
+    private static boolean isNearEdge(double x, double y, double x1, double y1, double x2, double y2) {
+        // Reject the vast majority of edges on their bounding box before doing any arithmetic.
+        if (x1 < x2 ? (x < x1 - TOLERANCE || x > x2 + TOLERANCE) : (x < x2 - TOLERANCE || x > x1 + TOLERANCE)) {
+            return false;
+        }
+        if (y1 < y2 ? (y < y1 - TOLERANCE || y > y2 + TOLERANCE) : (y < y2 - TOLERANCE || y > y1 + TOLERANCE)) {
+            return false;
+        }
+        double dx = x2 - x1;
+        double dy = y2 - y1;
+        double projection = ((x - x1) * dx + (y - y1) * dy) / (dx * dx + dy * dy);
+        if (projection < 0) {
+            projection = 0;
+        } else if (projection > 1) {
+            projection = 1;
+        }
+        double offsetX = x1 + projection * dx - x;
+        double offsetY = y1 + projection * dy - y;
+        return offsetX * offsetX + offsetY * offsetY <= TOLERANCE_SQUARED;
+    }
+
+    /** Whether this polygon's bounding box lies entirely within the given one. */
+    boolean isWithin(double boxMinX, double boxMinY, double boxMaxX, double boxMaxY) {
+        return minX >= boxMinX && maxX <= boxMaxX && minY >= boxMinY && maxY <= boxMaxY;
+    }
+}

--- a/core/src/main/java/net/iakovlev/timeshape/TimeZoneEngine.java
+++ b/core/src/main/java/net/iakovlev/timeshape/TimeZoneEngine.java
@@ -1,6 +1,5 @@
 package net.iakovlev.timeshape;
 
-import com.esri.core.geometry.Envelope;
 import com.github.luben.zstd.ZstdInputStream;
 import net.iakovlev.timeshape.proto.Geojson;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
@@ -233,12 +232,11 @@ public final class TimeZoneEngine implements Serializable {
         validateCoordinates(minLat, minLon, maxLat, maxLon);
         Stream<Geojson.Feature> featureStream = spliterateInputStream (f);
 
-        Envelope boundaries = new Envelope(minLon, minLat, maxLon, maxLat);
         return new TimeZoneEngine(
                 Index.build(
                         featureStream,
                         NUMBER_OF_TIMEZONES,
-                        boundaries,
+                        minLat, minLon, maxLat, maxLon,
                         accelerateGeometry));
     }
 

--- a/doc/Architecture.md
+++ b/doc/Architecture.md
@@ -17,9 +17,24 @@ is used instead of `double` to store geo coordinates in protobuf.
 This means, only 4+4=8 bytes are required for each point (latitude + longitude), instead of 8+8=16 bytes for `double`.
 Precision of `float` is good enough for the source data.
 
-At runtime, the code reads the packaged data and build a spatial index for querying. It uses 
-[quad tree](https://en.wikipedia.org/wiki/Quadtree) for indexing, provided by the 
-[Esri geometry API](https://github.com/Esri/geometry-api-java) Java library.
+At runtime, the code reads the packaged data and builds a spatial index for querying. Answering a
+query is two steps: narrowing the world down to the few polygons that may cover the coordinate, and
+testing the coordinate against each of them.
+
+The first step uses a uniform grid of roughly one degree per cell, covering the indexed area. Every
+cell holds the indices of the polygons whose bounding box overlaps it, in one flat `int` array, so
+looking up the candidates is a bit of arithmetic and an array offset.
+
+The second step is an even-odd point-in-polygon test. Each polygon keeps its rings in two flat
+`float` arrays (the same precision the packaged data has), and, when geometry acceleration is
+requested, an index that groups the edges by the latitude band they span. A query then only visits
+the edges that can possibly cross the query latitude, which for the larger time zones is a handful
+instead of the hundred thousand or so edges they are made of. Coordinates that sit within 1e-8
+degrees of an outline count as being inside it, which is what makes a point on a shared border
+belong to both of its time zones.
+
+Both steps are implemented in this repository, in `Index` and `PreparedPolygon`; the library has no
+third party geometry dependency.
 
 ## Build structure
 Timeshape uses [sbt](https://scala-sbt.org) as build system. The sbt build definition has 5 projects:
@@ -38,7 +53,7 @@ Other projects (`core` and `builder`), which must read or write the protobuf, us
 depend on `geojson-protobuf` in classpath sense.
 
 ### core
-This project contains the logic to read the data into a quad tree and provide API for querying it. It's the main project
+This project contains the logic to read the data into the spatial index and provide API for querying it. It's the main project
 with which the library users interact, and provides the main published artifact. It uses sbt feature called
 `resource generator` to create the protobuf file containing the time zone data. The code that actually generates the 
 protobuf data file is in the [builder](#builder) project. The resource generator is run by sbt automatically when necessary.
@@ -103,6 +118,8 @@ dependencies {
 ## Memory usage
 
 The `testApp` project provides memory usage estimate by using [JOL](http://openjdk.java.net/projects/code-tools/jol/).
-The current version's estimated footprint is roughly 128 MB of memory when the data for the whole world is loaded.
+With the data for the whole world loaded, the current version's estimated footprint is roughly 116 MB of memory with
+geometry acceleration enabled (which is what `testApp` measures), and roughly 64 MB without it, the difference being
+the per-polygon latitude index.
 It is possible to further limit the memory usage by reducing the amount of time zones loaded. This is implemented by a call to
 `TimeZoneEngine.initialize(double minlat, double minlon, double maxlat, double maxlon)`.


### PR DESCRIPTION
Every lookup used to descend an Esri quad tree and then hand the candidate polygons to `OperatorIntersects`, which walks all of their vertices. Europe/Berlin alone is 157k vertices, so a single query near Berlin cost about 4.5 ms.

## What changed

Queries are now answered in two steps, both implemented here:

* **`Index.Grid`** — a uniform one-degree grid maps a coordinate to the polygons whose bounding box covers its cell, which is a bit of arithmetic and one array offset instead of a tree descent with an iterator allocation.
* **`PreparedPolygon`** — keeps the rings in flat `float` arrays (the precision the packaged data already has) and runs an even-odd test over them. With geometry acceleration enabled it also indexes the edges by the latitude band they span, so a query visits a handful of edges rather than all of them.

Coordinates within 1e-8 degrees of an outline still count as inside it, which is the tolerance the previous backend applied and what makes a point on a shared border belong to both of its time zones.

## Results

Measured with the JMH benchmarks in this repository (throughput in ops/s, higher is better):

| Benchmark | Before | After | |
|---|---|---|---|
| `testAcceleratedEngine` | 36.2 | 252,055 | **6961×** |
| `testNonAcceleratedEngine` | 13.8 | 137.4 | **10.0×** |
| `testIndexQuery` | 223.6 | 4,751.7 | **21.2×** |
| `testQuadTree` | 986,699 | 161,928,578 | **164×** |
| `testSearchInMatchingGeometry` | 228.7 | 4,895.5 | **21.4×** |
| `testSearchInNonMatchingGeometry` | 434.9 | 3,888.2 | **8.9×** |
| `testQueryPoints` | 1.51 | 15.55 | **10.3×** |
| `testQueryPolyline` | 2.73 | 52.40 | **19.2×** |

For a single point lookup through the public `query()` API over uniformly random world coordinates — which is closer to a worst case than the city set above — the numbers are 996 µs → 106 µs unaccelerated (**9.4×**) and 304 µs → 0.55 µs accelerated (**555×**).

The world index also got smaller and quicker to build: 176 MB → 64 MB without acceleration, 181 MB → 116 MB with it, and initialization went from 2.0 s to 1.3 s.

## Correctness

Verified against the previous implementation over 600k coordinates: 300k uniformly random ones return exactly the same set of zones, and 300k sitting on or next to a polygon vertex differ only in that 2% of them now *also* report the neighbouring zone whose border they sit on. No coordinate lost a zone. The full test suite passes.

The order of `queryAll` is now ascending by zone, which the documentation already described as arbitrary.

## The accelerateGeometry default stays `false`

Worth a deliberate look, because the trade changed shape. Under the Esri backend the index was nearly free in memory (+2.6%, 176 → 181 MB) and bought 2.5×. The new one buys about 190× per lookup but costs +80% (64 → 116 MB), because it scales with polygon edge count rather than being a fixed-size raster.

Flipping the default would be safe against the previous release — 116 MB is still 34% below the 176 MB that `initialize()` uses today — but it would deny memory-constrained callers most of the reduction this PR gives them. So the default is unchanged, and the README now documents the trade with measured numbers instead of the old "approximately 2.5 times" sentence.

## Dependencies

The library no longer needs a third party geometry library, so `esri-geometry-api` is gone (948 KB). `jackson-core` went with it: it was declared only so that Esri, which needs it for JSON geometry parsing, resolved against the version the parent pom manages — nothing in `core` ever referenced it. That is another 594 KB. The managed version stays in the parent pom because the `builder` module does use Jackson.

The main artifact itself is effectively unchanged at ~23.0 MB, since it is 99.8% timezone data.

## Note on the benchmarks

`BasicGeoOperationsBenchmark` now measures the new internals. Its non-matching benchmark used to collect its geometries around Berlin, where every polygon whose bounding box covers the point also contains it, so it timed an empty loop; it now uses a point where several time zones overlap. The baseline quoted above for that one was re-measured on the old code with the same workload.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)